### PR TITLE
Fix the path decomposition

### DIFF
--- a/src/mapping.jl
+++ b/src/mapping.jl
@@ -329,11 +329,13 @@ The `vertex_order` can be a vector or one of the following inputs
 embed_graph(g::SimpleGraph; vertex_order=Branching()) = embed_graph(UnWeighted(), g; vertex_order)
 function embed_graph(mode, g::SimpleGraph; vertex_order=Branching())
     if vertex_order isa AbstractVector
-        L = PathDecomposition.Layout(g, collect(vertex_order))
+        L = PathDecomposition.Layout(g, collect(vertex_order[end:-1:1]))
     else
         L = pathwidth(g, vertex_order)
     end
-    ug = ugrid(mode, g, L.vertices; padding=2, nrow=L.vsep+1)
+    # we reverse the vertex order of the pathwidth result,
+    # because this order corresponds to the vertex-seperation.
+    ug = ugrid(mode, g, L.vertices[end:-1:1]; padding=2, nrow=L.vsep+1)
     return ug
 end
 


### PR DESCRIPTION
@minhthin1028 I notice that the ordering of vertex seperation is different from the vertex ordering of path decomposition. They are reversible to each other. Please check the mapping you have done to make sure they are correct.