### PR TITLE
Add support for the triangular-lattice based embedding

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,7 +29,8 @@ makedocs(;
         "Home" => "index.md",
         "Examples" => [
             "generated/tutorial.md",
-            "generated/unweighted.md"
+            "generated/unweighted.md",
+            "generated/weighted_lattice_comparison.md"
         ],
         "Reference" => "ref.md",
     ],

--- a/examples/weighted_lattice_comparison.jl
+++ b/examples/weighted_lattice_comparison.jl
@@ -1,0 +1,102 @@
+# # Weighted Mapping on Different Lattices
+
+# This page demonstrates weighted version of the Maximum Independent Set (MIS) or Maximum Weighted Independent Set (MWIS) mapping techniques from the paper "Embedding computationally hard problems in triangular Rydberg atom arrays". We compare two mapping approaches using the K₂,₃ bipartite graph as an example:
+#
+# 1. **King's Subgraph (KSG) mapping** on square lattices - the traditional approach
+# 2. **Triangular lattice mapping** - a more experimental-promising alternative
+#
+# Both methods preserve the optimal solution while enabling implementation on quantum hardware with different connectivity constraints.
+
+using UnitDiskMapping, Graphs, GenericTensorNetworks
+
+# ## Problem Setup: K₂,₃ Graph
+
+# We use the complete bipartite graph K₂,₃ as our test case. This graph has two groups of vertices: {1,2} and {3,4,5}, where every vertex in the first group connects to every vertex in the second group.
+
+k23_graph = SimpleGraph(5)
+add_edge!(k23_graph, 1, 3)
+add_edge!(k23_graph, 1, 4)
+add_edge!(k23_graph, 1, 5)
+add_edge!(k23_graph, 2, 3)
+add_edge!(k23_graph, 2, 4)
+add_edge!(k23_graph, 2, 5)
+
+show_graph(k23_graph)
+
+# For the MIS problem, we assign equal weights to all vertices. 
+source_weights = [0.5, 0.5, 0.5, 0.5, 0.5]
+
+# ## Square Lattice Mapping (KSG)
+
+# The KSG-based approach creates a regular square grid where vertices can only connect to their nearest and next nearest neighbors (i.e. diagonals).
+
+square_result = map_graph(Weighted(), k23_graph; vertex_order=MinhThiTrick())
+
+println("Square lattice grid size: ", square_result.grid_graph.size)
+println("Number of vertices: ", nv(square_result.grid_graph))
+println("MIS overhead: ", square_result.mis_overhead)
+
+# Visualize the mapping
+show_graph(square_result.grid_graph; show_number=false) 
+show_grayscale(square_result.grid_graph) # show weights in gray scale
+show_pins(square_result) # show pins in red
+
+# Solve the mapped problem
+square_mapped_weights = map_weights(square_result, source_weights)
+square_grid_graph, _ = graph_and_weights(square_result.grid_graph)
+square_solution = solve(GenericTensorNetwork(IndependentSet(square_grid_graph, square_mapped_weights)), 
+                       SingleConfigMax())[].c.data
+
+# Map back to source
+square_source_solution = map_config_back(square_result, collect(Int, square_solution))
+println("Square solution: ", square_source_solution)
+
+# ## Triangular Lattice Mapping
+
+# While King's subgraphs provide a systematic approach for encoding problems on square lattices, they are not optimal for two-dimensional quantum hardware. The power-law decay of Rydberg interaction strengths in real devices leads to poor approximation of unit-disk graphs, requiring extensive post-processing that lacks explainability.
+#
+# The triangular lattice encoding scheme addresses these limitations by utilizing triangular Rydberg atom arrays which only blocks atoms in the nearest neighbors. This approach reduces independence-constraint violations by approximately two orders of magnitude compared to King's subgraphs, substantially alleviating the need for post-processing in experiments.
+#
+# The automatic embedding scheme generates graphs on triangular lattices with slightly larger overhead compared to KSG, but remains quadratic. For further improvement like removing dangling vertices, we need to manually optimize the embedding currently.
+#
+
+
+triangular_result = map_graph(TriangularWeighted(), k23_graph; vertex_order=MinhThiTrick())
+
+println("Triangular lattice grid size: ", triangular_result.grid_graph.size)
+println("Number of vertices: ", nv(triangular_result.grid_graph))
+println("MIS overhead: ", triangular_result.mis_overhead)
+
+# Visualize the mapping
+show_graph(triangular_result.grid_graph; show_number=false)
+show_grayscale(triangular_result.grid_graph) # show weights in gray scale
+show_pins(triangular_result) # show pins in red
+
+# Solve the mapped problem
+triangular_mapped_weights = map_weights(triangular_result, source_weights)
+triangular_grid_graph, _ = graph_and_weights(triangular_result.grid_graph)
+triangular_solution = solve(GenericTensorNetwork(IndependentSet(triangular_grid_graph, triangular_mapped_weights)), 
+                           SingleConfigMax())[].c.data
+show_config(triangular_result.grid_graph, triangular_solution)
+
+# Map back to source
+triangular_source_solution = map_config_back(triangular_result, collect(Int, triangular_solution))
+println("Triangular solution: ", triangular_source_solution)
+
+# ## Verification and Comparison
+
+# To verify correctness, we solve the original problem directly and compare with both mapping approaches. All three methods should yield the same optimal solution value.
+
+# Solve original problem directly
+direct_solution = solve(GenericTensorNetwork(IndependentSet(k23_graph, source_weights)), 
+                       SingleConfigMax())[].c.data
+
+println("Direct solution: ", collect(Int, direct_solution))
+
+# Check all give same optimal value
+direct_value = sum(source_weights[i] for i in 1:5 if direct_solution[i] == 1)
+square_value = sum(source_weights[i] for i in 1:5 if square_source_solution[i] == 1)
+triangular_value = sum(source_weights[i] for i in 1:5 if triangular_source_solution[i] == 1)
+
+println("Optimal values - Direct: $direct_value, Square: $square_value, Triangular: $triangular_value")
+println("All correct: ", direct_value ≈ square_value ≈ triangular_value)

--- a/project/createmap.jl
+++ b/project/createmap.jl
@@ -1,5 +1,3 @@
-# TODO: Some interface has changed. We need to update the code.
-
 using UnitDiskMapping, GenericTensorNetworks, Graphs
 
 function mapped_entry_to_compact(s::Pattern)
@@ -37,35 +35,11 @@ function source_entry_to_configs(s::Pattern)
     return d
 end
 
-# function compute_mis_overhead(s)
-#     locs1, g1, pins1 = source_graph(s)
-#     locs2, g2, pins2 = mapped_graph(s)
-#     m1 = mis_compactify!(solve(IndependentSet(g1, openvertices=pins1), SizeMax()))
-#     m2 = mis_compactify!(solve(IndependentSet(g2, openvertices=pins2), SizeMax()))
-#     @assert nv(g1) == length(locs1) && nv(g2) == length(locs2)
-#     sig, diff = UnitDiskMapping.is_diff_by_const(GenericTensorNetworks.content.(m1), GenericTensorNetworks.content.(m2))
-#     @assert sig
-#     return diff
-# end
-
 function compute_mis_overhead(s)
     locs1, g1, pins1 = source_graph(s)
     locs2, g2, pins2 = mapped_graph(s)
-    m1 = mis_compactify!(solve(IndependentSet(g1, ones(Int, length(locs1))), SizeMax()))
-    m2 = mis_compactify!(solve(IndependentSet(g2, ones(Int, length(locs2))), SizeMax()))
-    @assert nv(g1) == length(locs1) && nv(g2) == length(locs2)
-    sig, diff = UnitDiskMapping.is_diff_by_const(GenericTensorNetworks.content.(m1), GenericTensorNetworks.content.(m2))
-    @assert sig
-    return diff
-end
-
-function compute_mis_overhead_weighted(s)
-    weighted_s = UnitDiskMapping.weighted(s)
-    locs1, g1, pins1 = source_graph(s)
-    locs2, g2, pins2 = mapped_graph(s)
-    m1 = mis_compactify!(solve(IndependentSet(g1, weighted_s.source_weights), SizeMax()))
-    m2 = mis_compactify!(solve(IndependentSet(g2, weighted_s.mapped_weights), SizeMax()))
-    @show m1, m2
+    m1 = mis_compactify!(solve(IndependentSet(g1, openvertices=pins1), SizeMax()))
+    m2 = mis_compactify!(solve(IndependentSet(g2, openvertices=pins2), SizeMax()))
     @assert nv(g1) == length(locs1) && nv(g2) == length(locs2)
     sig, diff = UnitDiskMapping.is_diff_by_const(GenericTensorNetworks.content.(m1), GenericTensorNetworks.content.(m2))
     @assert sig

--- a/project/createmap.jl
+++ b/project/createmap.jl
@@ -1,3 +1,5 @@
+# TODO: Some interface has changed. We need to update the code.
+
 using UnitDiskMapping, GenericTensorNetworks, Graphs
 
 function mapped_entry_to_compact(s::Pattern)
@@ -35,11 +37,35 @@ function source_entry_to_configs(s::Pattern)
     return d
 end
 
+# function compute_mis_overhead(s)
+#     locs1, g1, pins1 = source_graph(s)
+#     locs2, g2, pins2 = mapped_graph(s)
+#     m1 = mis_compactify!(solve(IndependentSet(g1, openvertices=pins1), SizeMax()))
+#     m2 = mis_compactify!(solve(IndependentSet(g2, openvertices=pins2), SizeMax()))
+#     @assert nv(g1) == length(locs1) && nv(g2) == length(locs2)
+#     sig, diff = UnitDiskMapping.is_diff_by_const(GenericTensorNetworks.content.(m1), GenericTensorNetworks.content.(m2))
+#     @assert sig
+#     return diff
+# end
+
 function compute_mis_overhead(s)
     locs1, g1, pins1 = source_graph(s)
     locs2, g2, pins2 = mapped_graph(s)
-    m1 = mis_compactify!(solve(IndependentSet(g1, openvertices=pins1), SizeMax()))
-    m2 = mis_compactify!(solve(IndependentSet(g2, openvertices=pins2), SizeMax()))
+    m1 = mis_compactify!(solve(IndependentSet(g1, ones(Int, length(locs1))), SizeMax()))
+    m2 = mis_compactify!(solve(IndependentSet(g2, ones(Int, length(locs2))), SizeMax()))
+    @assert nv(g1) == length(locs1) && nv(g2) == length(locs2)
+    sig, diff = UnitDiskMapping.is_diff_by_const(GenericTensorNetworks.content.(m1), GenericTensorNetworks.content.(m2))
+    @assert sig
+    return diff
+end
+
+function compute_mis_overhead_weighted(s)
+    weighted_s = UnitDiskMapping.weighted(s)
+    locs1, g1, pins1 = source_graph(s)
+    locs2, g2, pins2 = mapped_graph(s)
+    m1 = mis_compactify!(solve(IndependentSet(g1, weighted_s.source_weights), SizeMax()))
+    m2 = mis_compactify!(solve(IndependentSet(g2, weighted_s.mapped_weights), SizeMax()))
+    @show m1, m2
     @assert nv(g1) == length(locs1) && nv(g2) == length(locs2)
     sig, diff = UnitDiskMapping.is_diff_by_const(GenericTensorNetworks.content.(m1), GenericTensorNetworks.content.(m2))
     @assert sig

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -56,30 +56,82 @@ offset(p::Node, xy) = chxy(p, getxy(p) .+ xy)
 const WeightedNode{T<:Real} = Node{T}
 const UnWeightedNode = Node{ONE}
 
+############################ Grid Types ############################
+# Abstract grid geometry types
+abstract type AbstractGridType end
+
+struct SquareGrid <: AbstractGridType end
+struct TriangularGrid <: AbstractGridType end
+
 ############################ GridGraph ############################
-# GridGraph
-struct GridGraph{NT<:Node}
+# Main definition
+struct GridGraph{NT<:Node, GT<:AbstractGridType}
+    gridtype::GT
     size::Tuple{Int,Int}
     nodes::Vector{NT}
     radius::Float64
 end
+
+is_square_grid(g::GridGraph) = g.gridtype isa SquareGrid
+is_triangular_grid(g::GridGraph) = g.gridtype isa TriangularGrid
+
+# Base constructors (for any node/grid type)
+GridGraph(size::Tuple{Int,Int}, nodes::Vector{NT}, radius::Real) where {NT<:Node} =
+    GridGraph(SquareGrid(), size, nodes, radius)
+
+GridGraph(gridtype::GT, size::Tuple{Int,Int}, nodes::Vector{NT}, radius::Real) where {NT<:Node, GT<:AbstractGridType} =
+    GridGraph{NT, GT}(gridtype, size, nodes, radius)
+
 function Base.show(io::IO, grid::GridGraph)
-    println(io, "$(typeof(grid)) (radius = $(grid.radius))")
+    gridtype_name = grid.gridtype isa SquareGrid ? "Square" : "Triangular"
+    println(io, "$(gridtype_name)$(typeof(grid)) (radius = $(grid.radius))")
     print_grid(io, grid; show_weight=SHOW_WEIGHT[])
 end
 Base.size(gg::GridGraph) = gg.size
 Base.size(gg::GridGraph, i::Int) = gg.size[i]
 function graph_and_weights(grid::GridGraph)
-    return unit_disk_graph(getfield.(grid.nodes, :loc), grid.radius), getfield.(grid.nodes, :weight)
+    if is_triangular_grid(grid)
+        # For triangular grids, use physical positions
+        physical_locs = [physical_position(node) for node in grid.nodes]
+        return unit_disk_graph(physical_locs, grid.radius), getfield.(grid.nodes, :weight)
+    else
+        # For square grids, use original coordinates
+        return unit_disk_graph(getfield.(grid.nodes, :loc), grid.radius), getfield.(grid.nodes, :weight)
+    end
 end
-function Graphs.SimpleGraph(grid::GridGraph{Node{ONE}})
-    return unit_disk_graph(getfield.(grid.nodes, :loc), grid.radius)
+function Graphs.SimpleGraph(grid::GridGraph{Node{ONE}, GT}) where GT
+    if is_triangular_grid(grid)
+        # For triangular grids, use physical positions
+        physical_locs = [physical_position(node) for node in grid.nodes]
+        return unit_disk_graph(physical_locs, grid.radius)
+    else
+        # For square grids, use original coordinates
+        return unit_disk_graph(getfield.(grid.nodes, :loc), grid.radius)
+    end
 end
 coordinates(grid::GridGraph) = getfield.(grid.nodes, :loc)
+
+# Neighbor calculation with runtime grid type dispatch
 function Graphs.neighbors(g::GridGraph, i::Int)
-    [j for j in 1:nv(g) if i != j && distance(g.nodes[i], g.nodes[j]) <= g.radius]
+    if is_triangular_grid(g)
+        # Use physical positions for triangular grid distance calculation
+        [j for j in 1:nv(g) if i != j && triangular_distance(g.nodes[i], g.nodes[j]) <= g.radius]
+    else
+        # Default square grid calculation
+        [j for j in 1:nv(g) if i != j && distance(g.nodes[i], g.nodes[j]) <= g.radius]
+    end
 end
+
 distance(n1::Node, n2::Node) = sqrt(sum(abs2, n1.loc .- n2.loc))
+
+# Distance calculation for triangular grids using physical positions
+function triangular_distance(n1::Node, n2::Node)
+    # Convert to physical positions as in triangular.jl
+    p1 = physical_position(n1)
+    p2 = physical_position(n2)
+    return sqrt(sum(abs2, p1.loc .- p2.loc))
+end
+
 Graphs.nv(g::GridGraph) = length(g.nodes)
 Graphs.vertices(g::GridGraph) = 1:nv(g)
 

--- a/src/UnitDiskMapping.jl
+++ b/src/UnitDiskMapping.jl
@@ -7,7 +7,8 @@ using LuxorGraphPlot
 using LuxorGraphPlot.Luxor.Colors
 
 # Basic types
-export UnWeighted, Weighted
+export UnWeighted, Weighted, TriangularWeighted
+export SquareGrid, TriangularGrid
 export Cell, AbstractCell, SimpleCell
 export Node, WeightedNode, UnWeightedNode
 export graph_and_weights, GridGraph, coordinates
@@ -41,8 +42,8 @@ export pathwidth, PathDecompositionMethod, MinhThiTrick, Greedy
 
 @deprecate Branching MinhThiTrick
 
-include("utils.jl")
 include("Core.jl")
+include("utils.jl")
 include("pathdecomposition/pathdecomposition.jl")
 include("copyline.jl")
 include("dragondrop.jl")
@@ -51,6 +52,7 @@ include("logicgates.jl")
 include("gadgets.jl")
 include("mapping.jl")
 include("weighted.jl")
+include("triangular.jl")
 include("simplifiers.jl")
 include("extracting_results.jl")
 include("visualize.jl")

--- a/src/mapping.jl
+++ b/src/mapping.jl
@@ -7,7 +7,7 @@ struct TriangularWeighted end
 
 # Get spacing value based on mode
 get_spacing(::Union{UnWeighted, Weighted}) = 4
-get_spacing(::TriangularWeighted) = 6
+get_spacing(::TriangularWeighted) = 14
 
 Base.@kwdef struct MCell{WT} <: AbstractCell{WT}
     occupied::Bool = true

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1,0 +1,425 @@
+abstract type TriangularCrossPattern <: Pattern end
+
+struct TriCross{CON} <: TriangularCrossPattern end
+iscon(::TriCross{CON}) where {CON} = CON
+# · ⋅ ● ⋅ ·
+# ● ◆ ◉ ● ●
+# · ⋅ ◆ · ·
+# ⋅ ⋅ ● ⋅ ⋅
+# ⋅ ⋅ ● ⋅ ⋅
+# ⋅ ⋅ ● ⋅ ⋅
+function source_graph(::TriCross{true})
+    locs = Node.([(2,1), (2,2), (2,3), (2,4), (2,5), (1,3), (2,3), (3,3), (4,3), (5,3), (6,3)])
+    g = simplegraph([(1,2), (2,3), (3,4), (4,5), (6,7), (7,8), (8,9), (9,10), (10,11), (2,6)])
+    return locs, g, [1,6,11,5]
+end
+
+# ⋅ · ● ⋅ ⋅
+# ● ● ● ● ●
+# ⋅ ● ⋅ ● ⋅
+# ⋅ ● ● · ⋅
+# ⋅ · · ● ⋅
+# ⋅ ⋅ ● ● ⋅
+function mapped_graph(::TriCross{true})
+    locs = Node.([(1,3), (2,1), (2,2), (2,3), (2,4), (2,5), (3,2), (3,4), (4,2), (4,3), (5,4), (6,3), (6,4)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, false), [2,1,12,6]
+end
+Base.size(::TriCross{true}) = (6, 5)
+cross_location(::TriCross{true}) = (2, 3)
+connected_nodes(::TriCross{true}) = [2, 6]
+
+function weighted(p::TriCross{true})
+    sw = [2,2,2,2,2,2,2,2,2,2,2]
+    mw = [3,2,3,4,3,2,3,2,2,2,2,2,2]
+    return weighted(p, sw, mw)
+end
+
+# ⋅ ⋅ ● ⋅ ⋅
+# ● ● ◉ ● ●
+# ⋅ ⋅ ● ⋅ ⋅
+# ⋅ ⋅ ● ⋅ ⋅
+# ⋅ ⋅ ● ⋅ ⋅
+# ⋅ ⋅ ● ⋅ ⋅
+function source_graph(::TriCross{false})
+    locs = Node.([(2,1), (2,2), (2,3), (2,4), (2,5), (1,3), (2,3), (3,3), (4,3), (5,3), (6,3)])
+    g = simplegraph([(1,2), (2,3), (3,4), (4,5), (6,7), (7,8), (8,9), (9,10), (10,11)])
+    return locs, g, [1,6,11,5]
+end
+
+# ⋅ ⋅ ● ⋅ ⋅
+# ● ● ● ● ●
+# ● ● ● ● ·
+# ● ● · ⋅ ⋅
+# ● ⋅ · ⋅ ⋅
+# · ● ● ⋅ ⋅
+function mapped_graph(::TriCross{false})
+    locs = Node.([(1,3), (2,1), (2,2), (2,3), (2,4), (2,5), (3,1), (3,2), (3,3), (3,4), (4,1), (4,2), (5,1), (6,2), (6,3)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, false), [2,1,15,6]
+end
+Base.size(::TriCross{false}) = (6, 5)
+cross_location(::TriCross{false}) = (2,3)
+
+function weighted(p::TriCross{false})
+    sw = [2,2,2,2,2,2,2,2,2,2,2]
+    mw = [3,3,2,4,2,2,2,4,3,2,2,2,2,2,2]
+    return weighted(p, sw, mw)
+end
+
+struct TriTCon_left <: TriangularCrossPattern end
+# ⋅ ◆ ⋅ ⋅ ·
+# ◆ ● · · ·
+# ⋅ ● · ⋅ ·
+# ⋅ ● · · ·
+# · ● · · ·
+# · ● · · ·
+function source_graph(::TriTCon_left)
+    locs = Node.([(1,2), (2,1), (2,2), (3,2), (4,2), (5,2), (6,2)])
+    g = simplegraph([(1,2), (1,3), (3,4), (4,5), (5,6), (6,7)])
+    return locs, g, [1,2,7]
+end
+connected_nodes(::TriTCon_left) = [1, 2]
+
+# ⋅ ● ⋅ ⋅ ·
+# ● ● ● ● ·
+# ⋅ · ● ⋅ ·
+# ⋅ ● ● · ·
+# ● · · · ·
+# ● ● · · ·
+function mapped_graph(::TriTCon_left)
+    locs = Node.([(1,2), (2,1), (2,2), (2,3), (2,4), (3,3), (4,2), (4,3), (5,1), (6,1), (6,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1,2,11]
+end
+Base.size(::TriTCon_left) = (6,5)
+cross_location(::TriTCon_left) = (2,2)
+iscon(::TriTCon_left) = true
+
+function weighted(p::TriTCon_left)
+    sw = [2,1,2,2,2,2,2]
+    mw = [3,2,3,3,1,3,2,2,2,2,2]
+    return weighted(p, sw, mw)
+end
+
+struct TriTCon_down <: TriangularCrossPattern end
+# · · ·
+# · · ·
+# ◆ ● ●
+# ⋅ ◆ ·
+function source_graph(::TriTCon_down)
+    locs = Node.([(3,1), (3,2), (3,3), (4,2)])
+    g = simplegraph([(1,2), (2,3), (1,4)])
+    return locs, g, [1,4,3]
+end
+connected_nodes(::TriTCon_down) = [1, 4]
+
+# · · ·
+# · ● ·
+# · ● ·
+# ● ● ●
+function mapped_graph(::TriTCon_down)
+    locs = Node.([(2,2), (3,2), (4,1), (4,2), (4,3)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [3,4,5]
+end
+Base.size(::TriTCon_down) = (4,3)
+cross_location(::TriTCon_down) = (3,2)
+iscon(::TriTCon_down) = true
+
+function weighted(p::TriTCon_down)
+    sw = [2,2,2,1]
+    mw = [1,3,2,3,2]
+    return weighted(p, sw, mw)
+end
+
+struct TriTCon_up <: TriangularCrossPattern end
+# ⋅ ◆ ·
+# ◆ ● ●
+# · · ·
+# · · ·
+function source_graph(::TriTCon_up)
+    locs = Node.([(1,2), (2,1), (2,2), (2,3)])
+    g = simplegraph([(1,2), (2,3), (1,4)])
+    return locs, g, [2,1,4]
+end
+connected_nodes(::TriTCon_up) = [1, 2]
+
+# · ● ·
+# ● ● ●
+# · ● ·
+# · · ·
+function mapped_graph(::TriTCon_up)
+    locs = Node.([(1,2), (2,1), (2,2), (2,3), (3,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [2,1,4]
+end
+Base.size(::TriTCon_up) = (4,3)
+cross_location(::TriTCon_up) = (2,2)
+iscon(::TriTCon_up) = true
+
+function weighted(p::TriTCon_up)
+    sw = [1,2,2,2]
+    mw = [3,2,3,2,1]
+    return weighted(p, sw, mw)
+end
+
+struct TriTrivialTurn_left <: TriangularCrossPattern end
+# ⋅ ◆
+# ◆ ⋅
+function source_graph(::TriTrivialTurn_left)
+    locs = Node.([(1,2), (2,1)])
+    g = simplegraph([(1,2)])
+    return locs, g, [1,2]
+end
+# ⋅ ●
+# ● ⋅
+function mapped_graph(::TriTrivialTurn_left)
+    locs = Node.([(1,2),(2,1)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1,2]
+end
+Base.size(::TriTrivialTurn_left) = (2,2)
+cross_location(::TriTrivialTurn_left) = (2,2)
+iscon(::TriTrivialTurn_left) = true
+connected_nodes(::TriTrivialTurn_left) = [1, 2]
+
+function weighted(p::TriTrivialTurn_left)
+    sw = [1,1]
+    mw = [1,1]
+    return weighted(p, sw, mw)
+end
+
+struct TriTrivialTurn_right <: TriangularCrossPattern end
+# ◆ ·
+# · ◆
+function source_graph(::TriTrivialTurn_right)
+    locs = Node.([(1,1), (2,2)])
+    g = simplegraph([(1,2)])
+    return locs, g, [1,2]
+end
+# ⋅ ·
+# ● ●
+function mapped_graph(::TriTrivialTurn_right)
+    locs = Node.([(2,1),(2,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1,2]
+end
+Base.size(::TriTrivialTurn_right) = (2,2)
+cross_location(::TriTrivialTurn_right) = (1,2)
+iscon(::TriTrivialTurn_right) = true
+connected_nodes(::TriTrivialTurn_right) = [1, 2]
+
+function weighted(p::TriTrivialTurn_right)
+    sw = [1,1]
+    mw = [1,1]
+    return weighted(p, sw, mw)
+end
+
+struct TriEndTurn <: TriangularCrossPattern end
+# ⋅ ● ⋅ ⋅
+# ⋅ ● ● ⋅
+# ⋅ ⋅ ⋅ ⋅
+function source_graph(::TriEndTurn)
+    locs = Node.([(1,2), (2,2), (2,3)])
+    g = simplegraph([(1,2), (2,3)])
+    return locs, g, [1]
+end
+# ⋅ ● ⋅ ⋅
+# ⋅ ⋅ ⋅ ⋅
+# ⋅ ⋅ ⋅ ⋅
+function mapped_graph(::TriEndTurn)
+    locs = Node.([(1,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1]
+end
+Base.size(::TriEndTurn) = (3,4)
+cross_location(::TriEndTurn) = (2,2)
+iscon(::TriEndTurn) = false
+
+function weighted(p::TriEndTurn)
+    sw = [2,2,1]
+    mw = [1]
+    return weighted(p, sw, mw)
+end
+
+struct TriTurn <: TriangularCrossPattern end
+iscon(::TriTurn) = false
+# ⋅ ● ⋅ ⋅
+# ⋅ ● ⋅ ⋅
+# ⋅ ● ● ●
+# ⋅ ⋅ ⋅ ⋅
+function source_graph(::TriTurn)
+    locs = Node.([(1,2), (2,2), (3,2), (3,3), (3,4)])
+    g = simplegraph([(1,2), (2,3), (3,4), (4,5)])
+    return locs, g, [1,5]
+end
+
+# ⋅ ● ⋅ ⋅
+# ⋅ ● · ⋅
+# ● ⋅ ⋅ ●
+# ● ● ● ⋅
+function mapped_graph(::TriTurn)
+    locs = Node.([(1,2), (2,2), (3,1), (4,1), (4,2), (4,3), (3,4)])
+    locs, triangular_unitdisk_graph(locs, 1.1, true), [1,7]
+end
+Base.size(::TriTurn) = (4, 4)
+cross_location(::TriTurn) = (3,2)
+
+function weighted(p::TriTurn)
+    sw = [2,2,2,2,2]
+    mw = [2,2,2,2,2,2,2]
+    return weighted(p, sw, mw)
+end
+
+struct TriWTurn <: TriangularCrossPattern end
+# ⋅ ⋅ ⋅ ⋅
+# ⋅ ⋅ ● ●
+# ⋅ ● ● ⋅
+# ⋅ ● ⋅ ⋅
+function source_graph(::TriWTurn)
+    locs = Node.([(2,3), (2,4), (3,2),(3,3),(4,2)])
+    g = simplegraph([(1,2), (1,4), (3,4),(3,5)])
+    return locs, g, [2, 5]
+end
+# ⋅ ⋅ ⋅ ●
+# ⋅ ⋅ ● ⋅
+# ⋅ ● ● ⋅
+# ⋅ ● ⋅ ⋅
+function mapped_graph(::TriWTurn)
+    locs = Node.([(1,4), (2,3), (3,2), (3,3), (4,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1, 5]
+end
+Base.size(::TriWTurn) = (4, 4)
+cross_location(::TriWTurn) = (2,2)
+iscon(::TriWTurn) = false
+
+function weighted(p::TriWTurn)
+    sw = [2,2,2,2,2]
+    mw = [2,2,2,2,2]
+    return weighted(p, sw, mw)
+end
+
+struct TriBranchFix <: TriangularCrossPattern end
+# ⋅ ● ⋅ ⋅
+# ⋅ ● ● ⋅
+# ⋅ ● ● ⋅
+# ⋅ ● ⋅ ⋅
+function source_graph(::TriBranchFix)
+    locs = Node.([(1,2), (2,2), (2,3),(3,3),(3,2),(4,2)])
+    g = simplegraph([(1,2), (2,3), (3,4),(4,5), (5,6)])
+    return locs, g, [1, 6]
+end
+# ⋅ ● ⋅ ⋅
+# ⋅ ● ⋅ ⋅
+# ⋅ ● ⋅ ⋅
+# ⋅ ● ⋅ ⋅
+function mapped_graph(::TriBranchFix)
+    locs = Node.([(1,2),(2,2),(3,2),(4,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1, 4]
+end
+Base.size(::TriBranchFix) = (4, 4)
+cross_location(::TriBranchFix) = (2,2)
+iscon(::TriBranchFix) = false
+
+function weighted(p::TriBranchFix)
+    sw = [2,2,2,2,2,2]
+    mw = [2,2,2,2]
+    return weighted(p, sw, mw)
+end
+
+struct TriBranchFixB <: TriangularCrossPattern end
+# ⋅ ⋅ ⋅ ⋅
+# ⋅ ⋅ ● ⋅
+# ⋅ ● ● ⋅
+# ⋅ ● ⋅ ⋅
+function source_graph(::TriBranchFixB)
+    locs = Node.([(2,3),(3,2),(3,3),(4,2)])
+    g = simplegraph([(1,3), (2,3), (2,4)])
+    return locs, g, [1, 4]
+end
+# ⋅ ⋅ ⋅ ⋅
+# ⋅ ⋅ ⋅ ⋅
+# ⋅ ● ⋅ ⋅
+# ⋅ ● ⋅ ⋅
+function mapped_graph(::TriBranchFixB)
+    locs = Node.([(3,2),(4,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1, 2]
+end
+Base.size(::TriBranchFixB) = (4, 4)
+cross_location(::TriBranchFixB) = (2,2)
+iscon(::TriBranchFixB) = false
+
+function weighted(p::TriBranchFixB)
+    sw = [2,2,2,2]
+    mw = [2,2]
+    return weighted(p, sw, mw)
+end
+
+struct TriBranch <: TriangularCrossPattern end
+# ⋅ ● ⋅ ⋅
+# ⋅ ● ● ●
+# ⋅ ● ● ⋅
+# ⋅ ● ⋅ ⋅
+# ⋅ ● · ⋅
+# ⋅ ● · ⋅
+function source_graph(::TriBranch)
+    locs = Node.([(1,2),(2,2),(2,3),(2,4),(3,3),(3,2),(4,2),(5,2),(6,2)])
+    g = simplegraph([(1,2), (2,3), (3, 4), (3,5), (5,6), (6,7), (7,8), (8,9)])
+    return locs, g, [1, 4, 9]
+end
+# ⋅ ● ⋅ ⋅
+# ⋅ ● · ●
+# ● · ● ·
+# ⋅ ● ● ⋅
+# ● · ⋅ ⋅
+# ● ● ⋅ ⋅
+function mapped_graph(::TriBranch)
+    locs = Node.([(1,2),(2,2),(2,4),(3,1),(3,3),(4,2),(4,3),(5,1),(6,1),(6,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1,3,10]
+end
+Base.size(::TriBranch) = (6, 4)
+cross_location(::TriBranch) = (2,2)
+iscon(::TriBranch) = false
+
+function weighted(p::TriBranch)
+    sw = [2,2,3,2,2,2,2,2,2]
+    mw = [2,3,2,1,3,2,2,2,2,2]
+    return weighted(p, sw, mw)
+end
+
+const triangular_crossing_ruleset = (
+    TriCross{false}(),
+    TriCross{true}(),
+    TriTCon_left(),
+    TriTCon_up(),
+    TriTCon_down(),
+    TriTrivialTurn_left(),
+    TriTrivialTurn_right(),
+    TriEndTurn(),
+    TriTurn(),
+    TriWTurn(),
+    TriBranchFix(),
+    TriBranchFixB(),
+    TriBranch(),
+    )
+const crossing_ruleset_triangular_weighted = weighted.(triangular_crossing_ruleset)
+get_ruleset(::TriangularWeighted) = crossing_ruleset_triangular_weighted
+
+# Specialized mis_overhead for TriangularCrossPattern WeightedGadgets
+# For triangular patterns, we don't use the *2 multiplier from the general WeightedGadget method
+mis_overhead(w::WeightedGadget{<:TriangularCrossPattern}) = mis_overhead(w.gadget)
+
+# mis_overhead functions for TriangularCrossPattern types
+# These values should be computed properly using compute_mis_overhead function from project/createmap.jl
+# For now, using reasonable placeholder values based on the pattern complexity
+mis_overhead(::TriCross{true}) = 2
+mis_overhead(::TriCross{false}) = 3
+mis_overhead(::TriTCon_left) = 4
+mis_overhead(::TriTCon_down) = 1
+mis_overhead(::TriTCon_up) = 1
+mis_overhead(::TriTrivialTurn_left) = 0
+mis_overhead(::TriTrivialTurn_right) = 0
+mis_overhead(::TriEndTurn) = -2
+mis_overhead(::TriTurn) = 2
+mis_overhead(::TriWTurn) = 0
+mis_overhead(::TriBranchFix) = -2
+mis_overhead(::TriBranchFixB) = -2
+mis_overhead(::TriBranch) = 1
+
+for (T, centerloc) in [(:Turn, (2, 3)), (:Branch, (2, 3)), (:BranchFix, (3, 2)), (:BranchFixB, (3, 2)), (:WTurn, (3, 3)), (:EndTurn, (1, 2))]
+    @eval source_centers(::WeightedGadget{<:$T}) = [cross_location($T()) .+ (0, 1)]
+    @eval mapped_centers(::WeightedGadget{<:$T}) = [$centerloc]
+end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2,65 +2,66 @@ abstract type TriangularCrossPattern <: Pattern end
 
 struct TriCross{CON} <: TriangularCrossPattern end
 iscon(::TriCross{CON}) where {CON} = CON
-# · · · · · ⋅ ◆ ⋅ · · · · ·
-# ● ● ● ● ● ◆ ◉ ● ● ● ● ● ●
-# · · · · · ⋅ ● · · · · · ·
-# · · · · ⋅ ⋅ ● ⋅ ⋅ · · · ·
-# · · · · ⋅ ⋅ ● ⋅ ⋅ · · · ·
-# · · · · ⋅ ⋅ ● ⋅ ⋅ · · · ·
+# ⋅ ◆ ⋅ ·
+# ◆ ◉ ● ●
+# ⋅ ● · ·
+# · ● ⋅ ⋅
+# · ● ⋅ ⋅
+# ⋅ ● ⋅ ⋅
 function source_graph(::TriCross{true})
-    locs = Node.([(2,1), (2,2), (2,3), (2,4), (2,5), (2,6), (2,7), (2,8), (2,9), (2,10), (2,11), (2,12), (2,13), (1,7), (2,7), (3,7), (4,7), (5,7), (6,7)])
-    g = simplegraph([(1,2), (2,3), (3,4), (4,5), (5,6), (6,7), (7,8), (8,9), (9,10), (10,11), (11,12), (12,13), (14,15), (15,16), (16,17), (17,18), (18,19), (14,6)])
-    return locs, g, [1,14,13,19]
+    locs = Node.([(2,1), (2,2), (2,3), (2,4), (1,2), (2,2), (3,2), (4,2), (5,2), (6,2)])
+    g = simplegraph([(1,2), (2,3), (3,4), (5,6), (6,7), (7,8), (8,9), (9,10), (1,5)])
+    return locs, g, [1,5,10,4]
 end
-# ● · · · ⋅ · ● ⋅ ⋅ · · · ●
-# · ● · · ● ● ● ● ● · · ● ·
-# · ● ● ● ⋅ ● ⋅ ● ⋅ ● ● ● ·
-# · · · · ⋅ ● ● · ⋅ · · · ·
-# · · · · ⋅ · · ● ⋅ · · · ·
-# · · · · ⋅ ⋅ ● ● ⋅ · · · ·
+
+# · ● · ●
+# ● ● ● ·
+# · · ● ·
+# · ● ● ·
+# ● · · ·
+# ● ● · ·
 function mapped_graph(::TriCross{true})
-    locs = Node.([(1,1), (1,7), (1,13), (2,2), (2,5), (2,6), (2,7), (2,8), (2,9), (2,12), (3,2), (3,3), (3,4), (3,6), (3,8), (3,10), (3,11), (3,12), (4,6), (4,7), (5,8), (6,8), (6,7)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, false), [1,2,3,23]
+    locs = Node.([(1,2), (2,1), (2,2), (2,3), (1,4), (3,3), (4,2), (4,3), (5,1), (6,1), (6,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [2,1,11,5]
 end
-Base.size(::TriCross{true}) = (6, 13)
-cross_location(::TriCross{true}) = (2, 7)
-connected_nodes(::TriCross{true}) = [14,6]
+Base.size(::TriCross{true}) = (6, 4)
+cross_location(::TriCross{true}) = (2, 2)
+connected_nodes(::TriCross{true}) = [1,5]
 
 function weighted(p::TriCross{true})
-    sw = [2,2,2,2,2,2,2,2,2,2 ,2,2,2,2,2,2,2,2,2]
-    mw = [2,3,2,2,2,3,4,3,2,2 ,2,2,2,3,2,2,2,2 ,2,2,2,2,2]
+    sw = [2,2,2,2,2,2,2,2,2,2]
+    mw = [3,2,3,3,2,2,2,2,2,2,2]
     return weighted(p, sw, mw)
 end
 
-# ⋅ ⋅ ● ⋅ ⋅
-# ● ● ◉ ● ●
-# ⋅ ⋅ ● ⋅ ⋅
-# ⋅ ⋅ ● ⋅ ⋅
-# ⋅ ⋅ ● ⋅ ⋅
-# ⋅ ⋅ ● ⋅ ⋅
+# · ⋅ ⋅ ● ⋅ ⋅
+# ● ● ● ◉ ● ●
+# · ⋅ ⋅ ● ⋅ ⋅
+# · ⋅ ⋅ ● ⋅ ⋅
+# · ⋅ ⋅ ● ⋅ ⋅
+# · ⋅ ⋅ ● ⋅ ⋅
 function source_graph(::TriCross{false})
-    locs = Node.([(2,1), (2,2), (2,3), (2,4), (2,5), (1,3), (2,3), (3,3), (4,3), (5,3), (6,3)])
-    g = simplegraph([(1,2), (2,3), (3,4), (4,5), (6,7), (7,8), (8,9), (9,10), (10,11)])
-    return locs, g, [1,6,11,5]
+    locs = Node.([(2,2), (2,3), (2,4), (2,5), (2,6), (1,4), (2,4), (3,4), (4,4), (5,4), (6,4), (2,1)])
+    g = simplegraph([(1,2), (2,3), (3,4), (4,5), (6,7), (7,8), (8,9), (9,10), (10,11), (12,1)])
+    return locs, g, [12,6,11,5]
 end
 
-# ⋅ ⋅ ● ⋅ ⋅
-# ● ● ● ● ●
-# ● ● ● ● ·
-# ● ● · ⋅ ⋅
-# ● ⋅ · ⋅ ⋅
-# · ● ● ⋅ ⋅
+# · ⋅ ⋅ ● ⋅ ⋅
+# ● ● ● ● ● ●
+# · ● ● ● ● ·
+# · ● ● · ⋅ ⋅
+# · ● ⋅ · ⋅ ⋅
+# · · ● ● ⋅ ⋅
 function mapped_graph(::TriCross{false})
-    locs = Node.([(1,3), (2,1), (2,2), (2,3), (2,4), (2,5), (3,1), (3,2), (3,3), (3,4), (4,1), (4,2), (5,1), (6,2), (6,3)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, false), [2,1,15,6]
+    locs = Node.([(1,4), (2,2), (2,3), (2,4), (2,5), (2,6), (3,2), (3,3), (3,4), (3,5), (4,2), (4,3), (5,2), (6,3), (6,4), (2,1)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [16,1,15,6]
 end
-Base.size(::TriCross{false}) = (6, 5)
-cross_location(::TriCross{false}) = (2,3)
+Base.size(::TriCross{false}) = (6, 6)
+cross_location(::TriCross{false}) = (2, 4)
 
 function weighted(p::TriCross{false})
-    sw = [2,2,2,2,2,2,2,2,2,2,2]
-    mw = [3,3,2,4,2,2,2,4,3,2,2,2,2,2,2]
+    sw = [2,2,2,2,2,2,2,2,2,2,2,2]
+    mw = [3,3,2,4,2,2,2,4,3,2,2,2,2,2,2,2]
     return weighted(p, sw, mw)
 end
 
@@ -86,7 +87,7 @@ connected_nodes(::TriTCon_left) = [1, 2]
 # ● ● · · ·
 function mapped_graph(::TriTCon_left)
     locs = Node.([(1,2), (2,1), (2,2), (2,3), (2,4), (3,3), (4,2), (4,3), (5,1), (6,1), (6,2)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1,2,11]
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [1,2,11]
 end
 Base.size(::TriTCon_left) = (6,5)
 cross_location(::TriTCon_left) = (2,2)
@@ -100,11 +101,10 @@ end
 
 struct TriTCon_down <: TriangularCrossPattern end
 # · · ·
-# · · ·
 # ◆ ● ●
 # ⋅ ◆ ·
 function source_graph(::TriTCon_down)
-    locs = Node.([(3,1), (3,2), (3,3), (4,2)])
+    locs = Node.([(2,1), (2,2), (2,3), (3,2)])
     g = simplegraph([(1,2), (2,3), (1,4)])
     return locs, g, [1,4,3]
 end
@@ -112,26 +112,24 @@ connected_nodes(::TriTCon_down) = [1, 4]
 
 # · · ·
 # · ● ·
-# · ● ·
 # ● ● ●
 function mapped_graph(::TriTCon_down)
-    locs = Node.([(2,2), (3,2), (4,1), (4,2), (4,3)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [3,4,5]
+    locs = Node.([(2,2), (3,1), (3,2), (3,3)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [2,3,4]
 end
-Base.size(::TriTCon_down) = (4,3)
-cross_location(::TriTCon_down) = (3,2)
+Base.size(::TriTCon_down) = (3,3)
+cross_location(::TriTCon_down) = (2,2)
 iscon(::TriTCon_down) = true
 
 function weighted(p::TriTCon_down)
     sw = [2,2,2,1]
-    mw = [1,3,2,3,2]
+    mw = [2,2,3,2]
     return weighted(p, sw, mw)
 end
 
 struct TriTCon_up <: TriangularCrossPattern end
 # ⋅ ◆ ·
 # ◆ ● ●
-# · · ·
 # · · ·
 function source_graph(::TriTCon_up)
     locs = Node.([(1,2), (2,1), (2,2), (2,3)])
@@ -142,19 +140,18 @@ connected_nodes(::TriTCon_up) = [1, 2]
 
 # · ● ·
 # ● ● ●
-# · ● ·
 # · · ·
 function mapped_graph(::TriTCon_up)
-    locs = Node.([(1,2), (2,1), (2,2), (2,3), (3,2)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [2,1,4]
+    locs = Node.([(1,2), (2,1), (2,2), (2,3)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [2,1,4]
 end
-Base.size(::TriTCon_up) = (4,3)
+Base.size(::TriTCon_up) = (3,3)
 cross_location(::TriTCon_up) = (2,2)
 iscon(::TriTCon_up) = true
 
 function weighted(p::TriTCon_up)
     sw = [1,2,2,2]
-    mw = [3,2,3,2,1]
+    mw = [3,2,2,2]
     return weighted(p, sw, mw)
 end
 
@@ -170,7 +167,7 @@ end
 # ● ⋅
 function mapped_graph(::TriTrivialTurn_left)
     locs = Node.([(1,2),(2,1)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1,2]
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [1,2]
 end
 Base.size(::TriTrivialTurn_left) = (2,2)
 cross_location(::TriTrivialTurn_left) = (2,2)
@@ -195,7 +192,7 @@ end
 # ● ●
 function mapped_graph(::TriTrivialTurn_right)
     locs = Node.([(2,1),(2,2)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1,2]
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [1,2]
 end
 Base.size(::TriTrivialTurn_right) = (2,2)
 cross_location(::TriTrivialTurn_right) = (1,2)
@@ -222,7 +219,7 @@ end
 # ⋅ ⋅ ⋅ ⋅
 function mapped_graph(::TriEndTurn)
     locs = Node.([(1,2)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1]
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [1]
 end
 Base.size(::TriEndTurn) = (3,4)
 cross_location(::TriEndTurn) = (2,2)
@@ -237,29 +234,27 @@ end
 struct TriTurn <: TriangularCrossPattern end
 iscon(::TriTurn) = false
 # ⋅ ● ⋅ ⋅
-# ⋅ ● ⋅ ⋅
 # ⋅ ● ● ●
 # ⋅ ⋅ ⋅ ⋅
 function source_graph(::TriTurn)
-    locs = Node.([(1,2), (2,2), (3,2), (3,3), (3,4)])
-    g = simplegraph([(1,2), (2,3), (3,4), (4,5)])
-    return locs, g, [1,5]
+    locs = Node.([(1,2), (2,2), (2,3), (2,4)])
+    g = simplegraph([(1,2), (2,3), (3,4)])
+    return locs, g, [1,4]
 end
 
-# ⋅ ● ⋅ ⋅
 # ⋅ ● · ⋅
-# ● ⋅ ⋅ ●
-# ● ● ● ⋅
+# · ● · ●
+# · · ● ⋅
 function mapped_graph(::TriTurn)
-    locs = Node.([(1,2), (2,2), (3,1), (4,1), (4,2), (4,3), (3,4)])
-    locs, triangular_unitdisk_graph(locs, 1.1, true), [1,7]
+    locs = Node.([(1,2), (2,2), (3,3), (2,4)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [1,4]
 end
-Base.size(::TriTurn) = (4, 4)
-cross_location(::TriTurn) = (3,2)
+Base.size(::TriTurn) = (3, 4)
+cross_location(::TriTurn) = (2,2)
 
 function weighted(p::TriTurn)
-    sw = [2,2,2,2,2]
-    mw = [2,2,2,2,2,2,2]
+    sw = [2,2,2,2]
+    mw = [2,2,2,2]
     return weighted(p, sw, mw)
 end
 
@@ -279,7 +274,7 @@ end
 # ⋅ ● ⋅ ⋅
 function mapped_graph(::TriWTurn)
     locs = Node.([(1,4), (2,3), (3,2), (3,3), (4,2)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1, 5]
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [1, 5]
 end
 Base.size(::TriWTurn) = (4, 4)
 cross_location(::TriWTurn) = (2,2)
@@ -307,7 +302,7 @@ end
 # ⋅ ● ⋅ ⋅
 function mapped_graph(::TriBranchFix)
     locs = Node.([(1,2),(2,2),(3,2),(4,2)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1, 4]
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [1, 4]
 end
 Base.size(::TriBranchFix) = (4, 4)
 cross_location(::TriBranchFix) = (2,2)
@@ -335,7 +330,7 @@ end
 # ⋅ ● ⋅ ⋅
 function mapped_graph(::TriBranchFixB)
     locs = Node.([(3,2),(4,2)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1, 2]
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [1, 2]
 end
 Base.size(::TriBranchFixB) = (4, 4)
 cross_location(::TriBranchFixB) = (2,2)
@@ -361,13 +356,13 @@ function source_graph(::TriBranch)
 end
 # ⋅ ● ⋅ ⋅
 # ⋅ ● · ●
-# ● · ● ·
+# · · ● ·
 # ⋅ ● ● ⋅
 # ● · ⋅ ⋅
 # ● ● ⋅ ⋅
 function mapped_graph(::TriBranch)
-    locs = Node.([(1,2),(2,2),(2,4),(3,1),(3,3),(4,2),(4,3),(5,1),(6,1),(6,2)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, true), [1,3,10]
+    locs = Node.([(1,2),(2,2),(2,4),(3,3),(4,2),(4,3),(5,1),(6,1),(6,2)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, TriangularGrid(true)), [1,3,9]
 end
 Base.size(::TriBranch) = (6, 4)
 cross_location(::TriBranch) = (2,2)
@@ -375,7 +370,7 @@ iscon(::TriBranch) = false
 
 function weighted(p::TriBranch)
     sw = [2,2,3,2,2,2,2,2,2]
-    mw = [2,3,2,1,3,2,2,2,2,2]
+    mw = [2,2,2,3,2,2,2,2,2]
     return weighted(p, sw, mw)
 end
 
@@ -403,22 +398,21 @@ mis_overhead(w::WeightedGadget{<:TriangularCrossPattern}) = mis_overhead(w.gadge
 
 # mis_overhead functions for TriangularCrossPattern types
 # These values should be computed properly using compute_mis_overhead function from project/createmap.jl
-# For now, using reasonable placeholder values based on the pattern complexity
-mis_overhead(::TriCross{true}) = 4
+mis_overhead(::TriCross{true}) = 1
 mis_overhead(::TriCross{false}) = 3
 mis_overhead(::TriTCon_left) = 4
-mis_overhead(::TriTCon_down) = 1
-mis_overhead(::TriTCon_up) = 1
+mis_overhead(::TriTCon_down) = 0
+mis_overhead(::TriTCon_up) = 0
 mis_overhead(::TriTrivialTurn_left) = 0
 mis_overhead(::TriTrivialTurn_right) = 0
 mis_overhead(::TriEndTurn) = -2
-mis_overhead(::TriTurn) = 2
+mis_overhead(::TriTurn) = 0
 mis_overhead(::TriWTurn) = 0
 mis_overhead(::TriBranchFix) = -2
 mis_overhead(::TriBranchFixB) = -2
-mis_overhead(::TriBranch) = 1
+mis_overhead(::TriBranch) = 0
 
-for (T, centerloc) in [(:TriTurn, (4, 1)), (:TriBranch, (1,2)), (:TriBranchFix, (3, 2)), (:TriBranchFixB, (3, 2)), (:TriWTurn, (2, 3)), (:TriEndTurn, (1, 2))]
+for (T, centerloc) in [(:TriTurn, (1, 2)), (:TriBranch, (1,2)), (:TriBranchFix, (3, 2)), (:TriBranchFixB, (3, 2)), (:TriWTurn, (2, 3)), (:TriEndTurn, (1, 2))]
     @eval source_centers(::WeightedGadget{<:$T}) = [cross_location($T()) .+ (0, 1)]
     @eval mapped_centers(::WeightedGadget{<:$T}) = [$centerloc]
 end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2,35 +2,34 @@ abstract type TriangularCrossPattern <: Pattern end
 
 struct TriCross{CON} <: TriangularCrossPattern end
 iscon(::TriCross{CON}) where {CON} = CON
-# · ⋅ ● ⋅ ·
-# ● ◆ ◉ ● ●
-# · ⋅ ◆ · ·
-# ⋅ ⋅ ● ⋅ ⋅
-# ⋅ ⋅ ● ⋅ ⋅
-# ⋅ ⋅ ● ⋅ ⋅
+# · · · · · ⋅ ◆ ⋅ · · · · ·
+# ● ● ● ● ● ◆ ◉ ● ● ● ● ● ●
+# · · · · · ⋅ ● · · · · · ·
+# · · · · ⋅ ⋅ ● ⋅ ⋅ · · · ·
+# · · · · ⋅ ⋅ ● ⋅ ⋅ · · · ·
+# · · · · ⋅ ⋅ ● ⋅ ⋅ · · · ·
 function source_graph(::TriCross{true})
-    locs = Node.([(2,1), (2,2), (2,3), (2,4), (2,5), (1,3), (2,3), (3,3), (4,3), (5,3), (6,3)])
-    g = simplegraph([(1,2), (2,3), (3,4), (4,5), (6,7), (7,8), (8,9), (9,10), (10,11), (2,6)])
-    return locs, g, [1,6,11,5]
+    locs = Node.([(2,1), (2,2), (2,3), (2,4), (2,5), (2,6), (2,7), (2,8), (2,9), (2,10), (2,11), (2,12), (2,13), (1,7), (2,7), (3,7), (4,7), (5,7), (6,7)])
+    g = simplegraph([(1,2), (2,3), (3,4), (4,5), (5,6), (6,7), (7,8), (8,9), (9,10), (10,11), (11,12), (12,13), (14,15), (15,16), (16,17), (17,18), (18,19), (14,6)])
+    return locs, g, [1,14,13,19]
 end
-
-# ⋅ · ● ⋅ ⋅
-# ● ● ● ● ●
-# ⋅ ● ⋅ ● ⋅
-# ⋅ ● ● · ⋅
-# ⋅ · · ● ⋅
-# ⋅ ⋅ ● ● ⋅
+# ● · · · ⋅ · ● ⋅ ⋅ · · · ●
+# · ● · · ● ● ● ● ● · · ● ·
+# · ● ● ● ⋅ ● ⋅ ● ⋅ ● ● ● ·
+# · · · · ⋅ ● ● · ⋅ · · · ·
+# · · · · ⋅ · · ● ⋅ · · · ·
+# · · · · ⋅ ⋅ ● ● ⋅ · · · ·
 function mapped_graph(::TriCross{true})
-    locs = Node.([(1,3), (2,1), (2,2), (2,3), (2,4), (2,5), (3,2), (3,4), (4,2), (4,3), (5,4), (6,3), (6,4)])
-    return locs, triangular_unitdisk_graph(locs, 1.1, false), [2,1,12,6]
+    locs = Node.([(1,1), (1,7), (1,13), (2,2), (2,5), (2,6), (2,7), (2,8), (2,9), (2,12), (3,2), (3,3), (3,4), (3,6), (3,8), (3,10), (3,11), (3,12), (4,6), (4,7), (5,8), (6,8), (6,7)])
+    return locs, triangular_unitdisk_graph(locs, 1.1, false), [1,2,3,23]
 end
-Base.size(::TriCross{true}) = (6, 5)
-cross_location(::TriCross{true}) = (2, 3)
-connected_nodes(::TriCross{true}) = [2, 6]
+Base.size(::TriCross{true}) = (6, 13)
+cross_location(::TriCross{true}) = (2, 7)
+connected_nodes(::TriCross{true}) = [14,6]
 
 function weighted(p::TriCross{true})
-    sw = [2,2,2,2,2,2,2,2,2,2,2]
-    mw = [3,2,3,4,3,2,3,2,2,2,2,2,2]
+    sw = [2,2,2,2,2,2,2,2,2,2 ,2,2,2,2,2,2,2,2,2]
+    mw = [2,3,2,2,2,3,4,3,2,2 ,2,2,2,3,2,2,2,2 ,2,2,2,2,2]
     return weighted(p, sw, mw)
 end
 
@@ -136,7 +135,7 @@ struct TriTCon_up <: TriangularCrossPattern end
 # · · ·
 function source_graph(::TriTCon_up)
     locs = Node.([(1,2), (2,1), (2,2), (2,3)])
-    g = simplegraph([(1,2), (2,3), (1,4)])
+    g = simplegraph([(1,2), (2,3), (3,4)])
     return locs, g, [2,1,4]
 end
 connected_nodes(::TriTCon_up) = [1, 2]
@@ -405,7 +404,7 @@ mis_overhead(w::WeightedGadget{<:TriangularCrossPattern}) = mis_overhead(w.gadge
 # mis_overhead functions for TriangularCrossPattern types
 # These values should be computed properly using compute_mis_overhead function from project/createmap.jl
 # For now, using reasonable placeholder values based on the pattern complexity
-mis_overhead(::TriCross{true}) = 2
+mis_overhead(::TriCross{true}) = 4
 mis_overhead(::TriCross{false}) = 3
 mis_overhead(::TriTCon_left) = 4
 mis_overhead(::TriTCon_down) = 1
@@ -419,7 +418,7 @@ mis_overhead(::TriBranchFix) = -2
 mis_overhead(::TriBranchFixB) = -2
 mis_overhead(::TriBranch) = 1
 
-for (T, centerloc) in [(:Turn, (2, 3)), (:Branch, (2, 3)), (:BranchFix, (3, 2)), (:BranchFixB, (3, 2)), (:WTurn, (3, 3)), (:EndTurn, (1, 2))]
+for (T, centerloc) in [(:TriTurn, (4, 1)), (:TriBranch, (1,2)), (:TriBranchFix, (3, 2)), (:TriBranchFixB, (3, 2)), (:TriWTurn, (2, 3)), (:TriEndTurn, (1, 2))]
     @eval source_centers(::WeightedGadget{<:$T}) = [cross_location($T()) .+ (0, 1)]
     @eval mapped_centers(::WeightedGadget{<:$T}) = [$centerloc]
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,6 +41,30 @@ function unitdisk_graph(locs::AbstractVector, unit::Real)
     return g
 end
 
+function triangular_unitdisk_graph(locs::AbstractVector, unit::Real, parity::Bool=false)
+    # parity==false: crossing nodes on odd columns.
+    n = length(locs)
+    g = SimpleGraph(n)
+    physical_locs = physical_position.(locs, parity)
+    for i=1:n, j=i+1:n
+        if sum(abs2, physical_locs[i] .- physical_locs[j]) < unit ^ 2
+            add_edge!(g, i, j)
+        end
+    end
+    return g
+end
+
+function physical_position(node, parity=false)
+    i, j = node.loc
+    y = j * (√3 / 2)
+    if parity
+        x = i + (iseven(j) ? 0.5 : 0.0)
+    else
+        x = i + (isodd(j) ? 0.5 : 0.0)
+    end
+    return (x, y)
+end
+
 function is_independent_set(g::SimpleGraph, config)
     for e in edges(g)
         if config[e.src] == config[e.dst] == 1

--- a/src/visualize.jl
+++ b/src/visualize.jl
@@ -1,16 +1,15 @@
 # normalized to minimum weight and maximum weight
 
-# Helper function to convert grid coordinates to plot coordinates
+"""
+    plot_coordinates(gg::GridGraph, i::Int, j::Int, unit::Float64)
+
+Map grid coordinates to plot coordinates using the physical position
+for the grid type, then rotate to plotting frame.
+"""
 function plot_coordinates(gg::GridGraph, i::Int, j::Int, unit::Float64)
-    if is_triangular_grid(gg)
-        # Triangular grid layout: y = j * (√3 / 2), x = i + (iseven(j) ? 0.5 : 0.0)
-        x = (i + (isodd(j) ? 0.5 : 0.0)) * unit
-        y = j * (√3 / 2) * unit  # negative for downward y-axis
-        return (y, -x)
-    else
-        # Square grid layout (original)
-        return (j * unit, -i * unit)
-    end
+    # Use unified physical coordinates for both grid types
+    x, y = physical_position(Node(i, j), gg.gridtype)
+    return (y * unit, -x * unit)
 end
 
 function LuxorGraphPlot.show_graph(gg::GridGraph;

--- a/src/weighted.jl
+++ b/src/weighted.jl
@@ -97,7 +97,7 @@ end
 
 trace_centers(r::MappingResult) = trace_centers(r.lines, r.padding, r.mapping_history, r.spacing)
 function trace_centers(lines, padding, tape, spacing=4)
-    center_locations = map(x->center_location(x; padding, s=spacing) .+ (0, 1), lines)
+    center_locations = map(x->center_location(x, padding, spacing) .+ (0, 1), lines)
     for (gadget, i, j) in tape
         m, n = size(gadget)
         for (k, centerloc) in enumerate(center_locations)

--- a/src/weighted.jl
+++ b/src/weighted.jl
@@ -95,9 +95,9 @@ function move_center(w::WeightedGadgetTypes, nodexy, offset)
     error("center not found, source center = $(source_centers(w)), while offset = $(offset)")
 end
 
-trace_centers(r::MappingResult) = trace_centers(r.lines, r.padding, r.mapping_history)
-function trace_centers(lines, padding, tape)
-    center_locations = map(x->center_location(x; padding) .+ (0, 1), lines)
+trace_centers(r::MappingResult) = trace_centers(r.lines, r.padding, r.mapping_history, r.spacing)
+function trace_centers(lines, padding, tape, spacing=4)
+    center_locations = map(x->center_location(x; padding, s=spacing) .+ (0, 1), lines)
     for (gadget, i, j) in tape
         m, n = size(gadget)
         for (k, centerloc) in enumerate(center_locations)
@@ -122,12 +122,17 @@ function _map_configs_back(r::MappingResult{<:WeightedNode}, configs::AbstractVe
 end
 
 # simple rules for crossing gadgets
-for (GT, s1, m1, s3, m3) in [(:(Cross{true}), [], [], [], []), (:(Cross{false}), [], [], [], []),
-        (:(WTurn), [], [], [], []), (:(BranchFix), [], [], [], []), (:(Turn), [], [], [], []),
-        (:(TrivialTurn), [1, 2], [1, 2], [], []), (:(BranchFixB), [1], [1], [], []),
-        (:(EndTurn), [3], [1], [], []), (:(TCon), [2], [2], [], []),
-        (:(Branch), [], [], [4], [2]),
-        ]
+for (GT, s1, m1, s3, m3) in [
+    (:(Cross{true}), [], [], [], []), 
+    (:(Cross{false}), [], [], [], []),
+    (:(WTurn), [], [], [], []), 
+    (:(BranchFix), [], [], [], []), 
+    (:(Turn), [], [], [], []),
+    (:(TrivialTurn), [1, 2], [1, 2], [], []), 
+    (:(BranchFixB), [1], [1], [], []),
+    (:(EndTurn), [3], [1], [], []), 
+    (:(TCon), [2], [2], [], []),
+    (:(Branch), [], [], [4], [2]),]
     @eval function weighted(g::$GT)
         slocs, sg, spins = source_graph(g)
         mlocs, mg, mpins = mapped_graph(g)

--- a/test/mapping.jl
+++ b/test/mapping.jl
@@ -41,7 +41,7 @@ end
         mis_overhead1 = sum(x->mis_overhead(x[1]), tape)
         mis_overhead2 = sum(x->mis_overhead(x[1]), tape2)
         @show mis_overhead2
-        gp = GenericTensorNetwork(IndependentSet(SimpleGraph(ug3)); optimizer=GreedyMethod(nrepeat=10))
+        gp = GenericTensorNetwork(IndependentSet(SimpleGraph(ug3)))
         missize_map = solve(gp, SizeMax())[].n
         missize = solve(GenericTensorNetwork(IndependentSet(g)), SizeMax())[].n
         @test mis_overhead0 + mis_overhead1 + mis_overhead2 + missize == missize_map

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,3 +56,7 @@ end
 @testset "reduceto" begin
     include("reduceto.jl")
 end
+
+@testset "triangular" begin
+    include("triangular.jl")
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,5 @@
-using UnitDiskMapping: rotate90, reflectx, reflecty, reflectdiag, reflectoffdiag
+using UnitDiskMapping: rotate90, reflectx, reflecty, reflectdiag, reflectoffdiag, physical_position
+using UnitDiskMapping: Node, SquareGrid, TriangularGrid
 using Test
 
 @testset "symmetry operations" begin
@@ -9,4 +10,12 @@ using Test
     @test reflecty(loc, center) == (0,3)
     @test reflectdiag(loc, center) == (1,0)
     @test reflectoffdiag(loc, center) == (3,4)
+end
+
+@testset "physical position" begin
+    node = Node((2,3))
+    @test physical_position(node, SquareGrid()) == (2,3)
+    @test physical_position(node, TriangularGrid()) == (2.5, 3 * (√3 / 2))
+    @test physical_position(node, TriangularGrid(false)) == (2.5, 3 * (√3 / 2))
+    @test physical_position(node, TriangularGrid(true)) == (2, 3 * (√3 / 2))
 end


### PR DESCRIPTION
This pull request introduces support for mapping graphs onto triangular lattices in addition to the existing square lattice approach, enabling more flexible and realistic modeling for quantum hardware with different connectivity constraints. The changes include new grid types, a new mapping mode (`TriangularWeighted`), and significant refactoring to generalize grid spacing and physical positioning logic. An example and documentation updates are also provided to demonstrate and explain the new functionality.

**Triangular lattice support and grid generalization:**

- Added new grid types `SquareGrid` and `TriangularGrid` (with customizable column offset) as subtypes of a new `AbstractGridType`, and updated `GridGraph` to be parameterized by grid type. The physical position calculation and neighbor logic are now grid-type aware, supporting both square and triangular lattices.
- Introduced a new mapping mode `TriangularWeighted` and exported it, along with the new grid types, for external use. [[1]](diffhunk://#diff-d4a2d19d0287fca0dbe8fbd24b08be6e2e22f342367a8f95b5c0f50fc30f9e48L10-R11) [[2]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL1-R32)
- Refactored mapping logic to use a new `GridSpacing` structure, allowing flexible row and column spacing for different grid types. All mapping and gadget-placement functions now use this abstraction, and spacing is stored with the mapping grid and results. [[1]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL1-R32) [[2]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eR94-R97) [[3]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL92-R135) [[4]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL189-R222) [[5]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL233-R293) [[6]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL267-R305) [[7]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eR319-R338) [[8]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL316-R356) [[9]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL338-R396) [[10]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eR409) [[11]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eR440-R445)

**Triangular mapping implementation:**

- Added `TriangularWeighted` mapping logic, including grid construction, overhead calculation, and integration with simplification and gadget routines. The mapping functions now select grid type and spacing based on the chosen mode. [[1]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL1-R32) [[2]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL92-R135) [[3]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL316-R356) [[4]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eL338-R396) [[5]](diffhunk://#diff-40de8e709043e6424bce3c2488c95251bac7bba4f76a88a321aefeec569c020eR440-R445)

**Documentation and examples:**

- Added a new example file `examples/weighted_lattice_comparison.jl` demonstrating and comparing weighted graph mapping on square and triangular lattices, including visualization and solution verification.
- Updated documentation build configuration and included the new example in the docs navigation.

**Code organization:**

- Included the new `triangular.jl` file in the main module for triangular lattice support.
- Moved the `utils.jl` include to immediately after `Core.jl` for improved organization.